### PR TITLE
Hotkey support

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,3 +1,15 @@
+# DBD Map Overlay
+
+### Author
+- <p><a href="https://github.com/LucaFontanot" target="_blank">LucaFontanot</a></p>
+
+### Contributors  
+- <p><a href="https://github.com/Juli0q" target="_blank">Juli0q</a></p>
+
+---
+
+### Asset Credits
+
 - <p>3D maps by <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2899093390" target="_blank">SamoelColt</a></p>
 - <p>2D basic maps by <a href="https://discord.com/invite/hens333" target="_blank">Hens333</a></p>
 - <p>2D iconographic maps by <a href="https://dbdmaps.com/" target="_blank">EagerFace</a></p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbd-map",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Overlay for DBD maps",
   "main": "index.js",
   "author": "Luca <admin@lucaservers.com>",

--- a/src/index.html
+++ b/src/index.html
@@ -4,10 +4,15 @@
     <meta charset="UTF-8"/>
     <title>DBD Map Overlay</title>
     <link rel="stylesheet" href="./css/bootstrap.min.css"/>
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.bootstrap5.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown.min.css"/>
+
     <script src="https://dbdmap.lucaservers.com/api/challange.js?v=1.0"></script>
     <script>var $ = require('jquery');</script>
     <script>require('popper.js');</script>
     <script>var bootstrap = require('bootstrap');</script>
+    <script src="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/js/tom-select.complete.min.js"></script>
 
     <style>
         ::-webkit-scrollbar {
@@ -106,9 +111,9 @@
                     <h1 class="modal-title fs-5">Credits</h1>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body" id="creditsContent">
-                    ...
-                </div>
+                    <div id="creditsContent" class="text-start ps-3">
+                        ...
+                    </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                 </div>
@@ -124,31 +129,101 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <label for="sizeRange" class="form-label">Overlay Size</label>
-                    <input type="range" class="form-range" min="50" max="500" step="50" id="sizeRange">
-                    <label for="positionLabel" class="form-label">Overlay Position</label>
-                    <select class="form-select" id="positionLabel">
-                        <option value="1">Top Left</option>
-                        <option value="2">Top Right</option>
-                        <option value="3">Bottom Left</option>
-                        <option value="4">Bottom Right</option>
-                    </select>
-                    <label for="opacityRange" class="form-label">Opacity</label>
-                    <input type="range" class="form-range" min="0.1" max="1" step="0.1" id="opacityRange">
-                    <label for="hiddenCheck" class="form-label">Overlay Hidden</label>
-                    <input type="checkbox" id="hiddenCheck">
-                    <div>
-                        <label for="dragCheck" class="form-label">Overlay Draggable</label>
-                        <input type="checkbox" id="dragCheck">
-                        <button class="btn btn-dark" id="set-pos">Set position</button>
-                        <button class="btn btn-dark" id="unset-pos" style="display: none">Stop setting position</button>
+                    <!-- Nav tabs -->
+                    <ul class="nav nav-tabs" id="settingsTab" role="tablist">
+                        <li class="nav-item " role="presentation">
+                            <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#settings-overlay"
+                                    type="button" role="tab">General</button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="hotkeys-tab" data-bs-toggle="tab" data-bs-target="#settings-hotkeys"
+                                    type="button" role="tab">Hotkeys</button>
+                        </li>
+                    </ul>
+
+                    <div class="tab-content pt-3" id="settingsTabContent">
+
+                        <!-- Overlay Tab -->
+                        <div class="tab-pane fade show active" id="settings-overlay" role="tabpanel">
+                            <label for="sizeRange" class="form-label">Overlay Size</label>
+                            <input type="range" class="form-range" min="50" max="500" step="50" id="sizeRange">
+                            <label for="positionLabel" class="form-label">Overlay Position</label>
+                            <select class="form-select" id="positionLabel">
+                                <option value="1">Top Left</option>
+                                <option value="2">Top Right</option>
+                                <option value="3">Bottom Left</option>
+                                <option value="4">Bottom Right</option>
+                            </select>
+                            <label for="opacityRange" class="form-label">Opacity</label>
+                            <input type="range" class="form-range" min="0.1" max="1" step="0.1" id="opacityRange">
+                            <label for="hiddenCheck" class="form-label">Overlay Hidden</label>
+                            <input type="checkbox" id="hiddenCheck">
+                            <div>
+                                <label for="dragCheck" class="form-label">Overlay Draggable</label>
+                                <input type="checkbox" id="dragCheck">
+                                <button class="btn btn-dark" id="set-pos">Set position</button>
+                                <button class="btn btn-dark" id="unset-pos" style="display: none">Stop setting position</button>
+                            </div>
+                            <p>To set the position of the overlay. First set any map. Then start setting the position. Then use
+                                the mouse to move the window. At the end press "Stop setting position"</p>
+                            <p>Forgetting to stop setting position may result in the mouse having issue while in game</p>
+                        </div>
+
+                        <!-- Hotkeys Tab -->
+                        <div class="tab-pane fade" id="settings-hotkeys" role="tabpanel">
+                            <button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#addHotkeyModal">
+                                Add Hotkey
+                            </button>
+
+                            <h1 class="modal-title fs-5">Maps</h1>
+                            <table class="table table-bordered">
+                                <thead>
+                                <tr>
+                                    <th>Hotkey</th>
+                                    <th>Map</th>
+                                    <th>Creator</th>
+                                    <th></th>
+                                </tr>
+                                </thead>
+                                <tbody id="hotkeyList">
+                                </tbody>
+                            </table>
+
+                            <div class="alert alert-secondary d-flex flex-column gap-1 py-2 mb-4">
+                                <strong class="fs-6 mb-1">Default hotkeys</strong>
+                                <span><kbd>Cmd / Ctrl + P</kbd> – Reload Map when in a Lobby</span>
+                                <span><kbd>Cmd / Ctrl + H</kbd> – Hide currently open Map</span>
+                            </div>
+                        </div>
                     </div>
-                    <p>To set the position of the overlay. First set any map. Then start setting the position. Then use
-                        the mouse to move the window. At the end press "Stop setting position"</p>
-                    <p>Forgetting to stop setting position may result in the mouse having issue while in game</p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Hotkey modal-->
+    <div class="modal fade" id="addHotkeyModal" tabindex="-1" aria-hidden="true" style="color: black">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title black">Bind New Hotkey</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <label for="hotkeyInput" class="form-label">Press a key combination</label>
+                    <input type="text" class="form-control" id="hotkeyInput" placeholder="Press a key..." readonly>
+                    <label for="selectCreator" class="form-label mt-3">Select Creator</label>
+                    <select id="selectCreator" class="form-select mb-3"></select>
+
+                    <label for="selectMap" class="form-label mt-3">Select Map</label>
+                    <select id="selectMap" class="form-select" autocomplete="off">
+                        <option value="">Select...</option>
+                    </select>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="saveHotkeyBtn" data-bs-dismiss="modal" onclick="this.blur()">Save Hotkey</button>
                 </div>
             </div>
         </div>

--- a/src/js/hotkeys.js
+++ b/src/js/hotkeys.js
@@ -1,0 +1,226 @@
+const {debugLog} = require("./logger");
+const { ipcRenderer } = require('electron');
+
+class Hotkeys {
+
+    constructor(images) {
+        debugLog("hotkeys::constructor::called");
+        this.images = images;
+        this.recordingHotkey = false;
+        this.hotkeys = {};
+    }
+
+    showToast(message, isSuccess = true) {
+        const toastEl = document.getElementById('hotkeyToast');
+        const toastBody = document.getElementById('hotkeyToastBody');
+
+        toastBody.textContent = message;
+
+        toastEl.classList.remove('bg-success', 'bg-danger');
+        toastEl.classList.add(isSuccess ? 'bg-success' : 'bg-danger');
+
+        const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
+        toast.show();
+    }
+
+    splitCreatorAndMap(mapPath) {
+        const segments = mapPath.split('/').filter(Boolean);
+
+        const creator = segments[0] ?? '';
+        const last    = segments.at(-1) ?? '';
+        const map     = last.replace(/\.[^.]+$/, '');
+
+        return { creator, map };
+    }
+
+    updateHotkeys() {
+        const $list = $('#hotkeyList').empty();
+
+        for (const [hotkey, { id, mapKey }] of Object.entries(this.hotkeys)) {
+            const { creator, map } = this.splitCreatorAndMap(mapKey);
+
+            const $row = $(`
+                <tr data-id="${id}">
+                    <td>${hotkey}</td>
+                    <td>${map}</td>
+                    <td>${creator}</td>
+                </tr>
+            `);
+            $row.append(this.trashCell(id));
+            $list.append($row);
+        }
+    }
+
+    trashCell(id) {
+        return /* html */`
+            <td class="text-center">
+                <button type="button"
+                        class="delete-row btn btn-link p-0"
+                        data-id="${id}"
+                        title="Delete row">
+                    <i class="fa fa-trash"></i>
+                </button>
+            </td>
+        `;
+    }
+
+    loadTable() {
+        $('#hotkeyList').on('click', '.delete-row', (e) => {
+            const id   = $(e.currentTarget).data('id');
+            const $row = $(e.currentTarget).closest('tr');
+
+            $row.remove();
+
+            for (const [hotkey, obj] of Object.entries(this.hotkeys)) {
+                if (obj.id === id) {
+                    delete this.hotkeys[hotkey];
+                    break;
+                }
+            }
+
+            ipcRenderer.send('delete-hotkey', id);
+        });
+    }
+
+    saveHotkeyToFile() {
+        const settings = {
+            hotkey: $('#hotkeyInput').val().replace(/\s*\+\s*/g, '+'),
+            mapkey: $('#selectMap').val()
+        };
+        ipcRenderer.send('save-hotkeys', settings);
+    }
+
+    registerHotkeys(hotkeys) {
+        ipcRenderer.send('register-hotkeys', hotkeys);
+    }
+
+    async loadHotkeys() {
+        const mapDict = this.images.mapDictionary;
+
+        new TomSelect("#selectCreator", {
+            placeholder: "Select a creator...",
+            allowEmptyOption: false
+        });
+
+        this.populateCreatorSelect(mapDict);
+
+        const initialCreator = Object.keys(mapDict)[0];
+        this.populateMapSelectForCreator(mapDict, initialCreator);
+
+        $("#selectCreator").on("change", (e) => {
+            const selectedCreator = $(e.target).val();
+            this.populateMapSelectForCreator(mapDict, selectedCreator);
+        });
+
+        this.loadCapture()
+
+        ipcRenderer.on('hotkey-pressed', (event, mapKey) => {
+            let mapIamgePath = this.images.pathLookup[mapKey]
+            const response = this.images.sendMap(mapIamgePath, "standard");
+            if (response) {
+                debugLog("hotkey::setMap::success", "Map set successfully");
+            } else {
+                debugLog("hotkey::setMap::error", "Failed to set map");
+            }
+        });
+
+        ipcRenderer.on('hotkey-updated', (event, hotkeys) => {
+            this.hotkeys = hotkeys;
+            this.updateHotkeys()
+        });
+        ipcRenderer.send('load-hotkeys');
+        this.loadTable()
+    }
+
+    populateCreatorSelect(mapDict) {
+        const select = document.querySelector("#selectCreator");
+        if (select.tomselect) {
+            select.tomselect.clearOptions();
+
+            Object.keys(mapDict).forEach(creator => {
+                select.tomselect.addOption({ value: creator, text: creator });
+            });
+
+            select.tomselect.refreshOptions(false);
+            select.tomselect.setValue(Object.keys(mapDict)[0]);
+        }
+    }
+
+
+    populateMapSelectForCreator(mapDict, creator) {
+        const $select = $("#selectMap");
+
+        if ($select[0].tomselect) {
+            $select[0].tomselect.destroy();
+        }
+
+        $select.empty().append('<option value="">Select...</option>');
+
+        const realms = mapDict[creator];
+        Object.entries(realms).forEach(([realm, mapNames]) => {
+            const optgroup = $('<optgroup>').attr('label', realm);
+
+            mapNames.forEach(mapName => {
+                const value = `${creator}/${realm}/${mapName}`;
+                const displayName = mapName.replace(/\.[^/.]+$/, '');
+                const option = $('<option>').val(value).text(displayName);
+                optgroup.append(option);
+            });
+
+            $select.append(optgroup);
+        });
+
+        new TomSelect("#selectMap", {
+            placeholder: "Select a map...",
+            allowEmptyOption: true
+        });
+    }
+
+    
+    loadCapture() {
+        const self = this;
+
+        $('#hotkeyInput').on('click', function () {
+            self.recordingHotkey = true;
+            $(this).val('').attr('placeholder', 'Listening...');
+        });
+
+        $(document).on('keydown', function (e) {
+            if (!self.recordingHotkey) return;
+
+            e.preventDefault();
+
+            const keys = [];
+
+            if (e.ctrlKey) keys.push('Ctrl');
+            if (e.metaKey) keys.push('Meta');
+            if (e.altKey) keys.push('Alt');
+            if (e.shiftKey) keys.push('Shift');
+
+            const key = e.key;
+
+            if (!['Control', 'Shift', 'Alt', 'Meta'].includes(key)) {
+                const displayKey = key.length === 1 ? key.toUpperCase() : key;
+                keys.push(displayKey);
+            }
+
+            const hotkeyString = keys.join(' + ');
+
+            $('#hotkeyInput')
+                .val(hotkeyString)
+                .attr('placeholder', hotkeyString);
+        });
+
+        $(document).on('click', function (e) {
+            if (!$(e.target).is('#hotkeyInput')) {
+                self.recordingHotkey = false;
+            }
+        });
+
+        $("#saveHotkeyBtn").on("click", () => {
+            this.saveHotkeyToFile();
+        });
+    }
+}
+
+module.exports = Hotkeys;

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -90,10 +90,10 @@ class Images {
         const thisRef = this;
         $("#obsOpen").on("click", function (ev) {
             ipcRenderer.send('obs-open');
-            thisRef.sendMap(lastMap, lastMapType)
+            thisRef.sendMap(this.lastMap, this.lastMapType)
         })
         $("#hide").on("click", function (ev) {
-            thisRef.sendMap("", lastMapType)
+            thisRef.sendMap("", this.lastMapType)
         })
         $("#searchbar").on("input", function (ev) {
             thisRef.displayImages($(this).val())

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -7,6 +7,7 @@ const Custom = require("./js/custom.js");
 const Privacy = require("./js/privacy.js");
 const {BASEURL} = require("./js/consts");
 const Images = require("./js/images.js");
+const Hotkeys = require("./js/hotkeys.js")
 const Options = require("./js/options.js");
 
 let timeoutHide = null;
@@ -40,6 +41,12 @@ const settings = new Settings(api);
 const images = new Images(api, settings);
 
 /**
+ * Hotkeys instance for handling the main view
+ * @type {Images}
+ */
+const hotkeys = new Hotkeys(images);
+
+/**
  * Lobby instance for managing the lobby state and interactions.
  * @type {Lobby}
  */
@@ -70,6 +77,7 @@ const custom = new Custom(images);
     await images.remoteUpdateImages()
     await images.displayImages("")
     await custom.generateCustomList()
+    await hotkeys.loadHotkeys()
     setTimeout(function () {
         $('#warning').slideUp();
     }, 10000);
@@ -114,8 +122,15 @@ window.leaveLobby = function (){
 /**
  * If shortcut key is pressed, checks for lobby updates.
  */
-ipcRenderer.on('shortcut-key-pressed', async (event) => {
+ipcRenderer.on('check-lobby-update', async (event) => {
     lobby.checkLobbyUpdate()
+});
+
+/**
+ * If shortcut key is pressed, hide current map.
+ */
+ipcRenderer.on('hide-map', async (event) => {
+    images.sendMap("", images.lastMapType)
 });
 
 window.addCustomMap = function () {


### PR DESCRIPTION
Adds configurable hotkeys to select maps (defaults: Ctrl/Cmd + P to reload map, Ctrl/Cmd + H to hide), brings a new “Hotkeys” tab in Settings, bumps the app to v1.2.5, and refreshes CREDITS.
![image](https://github.com/user-attachments/assets/a1327e24-594a-4879-93b9-f0f1a95ca55b)
I am only able to test on Linux; I would appreciate it if someone could test it on Windows + Mac.

Resolves #6 
