### PR TITLE
Allow setting map via show-map argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,24 @@ This software is licensed under the Apache 2.0 License
 This means you can use it for free, modify it, and distribute it as long as you give credit to the original author and don't hold them liable.
 This software is provided as is, without any warranty or guarantee of any kind.
 Not affiliated with Dead by Daylight, Behaviour Interactive, or any of their partners.
+## Command-line usage
+You can start the app with a map command to display a specific map in the **already** running instance.
+**Usage:**
+```bash
+dbd-map-overlay show-map="Creator/Realm/MapName"
+```
+- If the application is not running yet, it will start normally and not apply the map.
+- If the application is already running, the map will be updated in the background.
+- If no map is passed and the app is already running, a popup will inform you that it's already open.
+**Map Keys:**
+Map keys follow this format:
+``
+Creator/Realm/MapName
+```
+Example:
+```
+SamoelColt/The Macmillan Estate/Suffocation Pit
+```
+- The key is case-insensitive.
+- File extensions are not required.
+- If the map name isn't found exactly, the closest match will be used.

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -101,6 +101,15 @@ class Images {
         $("#creatorSelect").on("input", function (ev) {
             thisRef.displayImages($("#searchbar").val())
         })
+        ipcRenderer.on('show-map-command', (event, arg) => {
+            let mapIamgePath = this.findClosestMapMatch(arg)
+            const response = this.sendMap(mapIamgePath, "standard");
+            if (response) {
+                debugLog("mapCommand::setMap::success", "Map set successfully");
+            } else {
+                debugLog("mapCommand::setMap::error", "Failed to set map");
+            }
+        });
     }
 
     searchMaps(name = '', creator = '') {
@@ -192,6 +201,25 @@ class Images {
 
         return result;
     }
+
+    findClosestMapMatch(mapKey) {
+        const normalizedKey = mapKey.replace(/\\/g, '/').trim().toLowerCase();
+
+        for (const key of Object.keys(this.pathLookup)) {
+            const keyWithoutExt = key.replace(/\.[^.]+$/, '').toLowerCase();
+            if (keyWithoutExt === normalizedKey) {
+                return this.pathLookup[key];
+            }
+        }
+
+        const matches = Object.keys(this.pathLookup).filter(key => key.toLowerCase().includes(normalizedKey));
+        if (matches.length > 0) {
+            return this.pathLookup[matches[0]];
+        }
+
+        return null;
+    }
+
 
     async invalidateCache() {
         debugLog("images::invalidateCache::called");


### PR DESCRIPTION
You can now launch a second instance of app with show-map=Creator/Realm/MapName to open a map directly.
If the app is already running, it forwards the command via IPC.
If no argument is passed and it's already open, a popup tells the user.

I created this for Stream Deck support.