### PR TITLE
Stream controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,24 @@ This software is licensed under the Apache 2.0 License
 This means you can use it for free, modify it, and distribute it as long as you give credit to the original author and don't hold them liable.
 This software is provided as is, without any warranty or guarantee of any kind.
 Not affiliated with Dead by Daylight, Behaviour Interactive, or any of their partners.
+## Command-line usage
+You can start the app with a map command to display a specific map in the **already** running instance.
+**Usage:**
+```bash
+dbd-map-overlay show-map="Creator/Realm/MapName"
+```
+- If the application is not running yet, it will start normally and not apply the map.
+- If the application is already running, the map will be updated in the background.
+- If no map is passed and the app is already running, a popup will inform you that it's already open.
+**Map Keys:**
+Map keys follow this format:
+``
+Creator/Realm/MapName
+```
+Example:
+```
+SamoelColt/The Macmillan Estate/Suffocation Pit
+```
+- The key is case-insensitive.
+- File extensions are not required.
+- If the map name isn't found exactly, the closest match will be used.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,42 @@ This software is licensed under the Apache 2.0 License
 This means you can use it for free, modify it, and distribute it as long as you give credit to the original author and don't hold them liable.
 This software is provided as is, without any warranty or guarantee of any kind.
 Not affiliated with Dead by Daylight, Behaviour Interactive, or any of their partners.
+## Stream Deck Support
+
+The app includes a config generator for [Stream Controller](https://github.com/StreamController/StreamController), allowing you to control maps directly from your Stream Deck.
+
+**Requirements:**
+- Linux
+- [Stream Controller](https://github.com/StreamController/StreamController)
+- Font Awesome plugin installed in Stream Controller (for navigation icons)
+
+**How to use:**
+1. Open the app and go to **Settings** → **Stream Deck**
+2. Select your Stream Controller installation type:
+    - **Flatpak**: Automatically uses the default Flatpak paths
+    - **Manual**: Choose your own output directory
+3. Click **Create Configs** and select:
+    - Number of buttons on your Stream Deck
+    - Command prefix (default: `dbd-map-tool`)
+    - Map creator whose maps you want to use
+4. The app will generate Stream Controller configuration files with:
+    - Main pages showing all realms for the selected creator
+    - Individual realm pages with all maps
+    - Navigation buttons to move between pages
+    - Automatic pagination for large collections
+
+**Features:**
+- Supports any Stream Deck size (6, 15, 32 buttons, etc.)
+- Automatic page navigation with arrow buttons
+- Organizes maps by creator and realm
+- Uses the command-line interface for seamless integration
+- Smart button labeling that splits long map names across multiple lines
+
+The generated configurations will create a hierarchical navigation system where you can browse through realms and select specific maps directly from your Stream Deck.
+
 ## Command-line usage
 You can start the app with a map command to display a specific map in the **already** running instance.
+
 **Usage:**
 ```bash
 dbd-map-overlay show-map="Creator/Realm/MapName"
@@ -38,7 +72,8 @@ dbd-map-overlay show-map="Creator/Realm/MapName"
 - If the application is not running yet, it will start normally and not apply the map.
 - If the application is already running, the map will be updated in the background.
 - If no map is passed and the app is already running, a popup will inform you that it's already open.
-**Map Keys:**
+
+- **Map Keys:**
 Map keys follow this format:
 ``
 Creator/Realm/MapName
@@ -50,3 +85,4 @@ SamoelColt/The Macmillan Estate/Suffocation Pit
 - The key is case-insensitive.
 - File extensions are not required.
 - If the map name isn't found exactly, the closest match will be used.
+

--- a/index.js
+++ b/index.js
@@ -155,6 +155,8 @@ function createWindow() {
     })
     win.loadFile('src/index.html')
 
+    win.webContents.openDevTools()
+
     win.webContents.setWindowOpenHandler(({url}) => {
         shell.openExternal(url);
         return {action: 'deny'};
@@ -430,6 +432,37 @@ function createWindow() {
         }
     });
 
+    ipcMain.handle('dialog:selectDirectory', async () => {
+        const result = await dialog.showOpenDialog({
+            properties: ['openDirectory'],
+            title: 'Select Stream Controller Directory'
+        });
+        return result;
+    });
+
+    ipcMain.handle('streamdeck:saveConfig', async (event, filePath, config) => {
+        try {
+            const dir = path.dirname(filePath);
+            await fs.mkdir(dir, { recursive: true }, (err) => {
+                if (err) {
+                    console.error("Failed to create directory:", err);
+                    return;
+                }
+            });
+            
+            await fs.writeFile(filePath, JSON.stringify(config, null, 2), (err) => {
+                if (err) {
+                    console.error("Failed to create directory:", err);
+                    return;
+                }
+            });
+            
+            return { success: true };
+        } catch (error) {
+            console.error('Error saving config:', error);
+            throw error;
+        }
+    });
 
     win.on("closed", () => {
         overlayWindow.close()

--- a/src/index.html
+++ b/src/index.html
@@ -139,6 +139,10 @@
                             <button class="nav-link" id="hotkeys-tab" data-bs-toggle="tab" data-bs-target="#settings-hotkeys"
                                     type="button" role="tab">Hotkeys</button>
                         </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="hotkeys-tab" data-bs-toggle="tab" data-bs-target="#settings-stream-deck"
+                                    type="button" role="tab">Stream Deck</button>
+                        </li>
                     </ul>
 
                     <div class="tab-content pt-3" id="settingsTabContent">
@@ -193,6 +197,49 @@
                                 <strong class="fs-6 mb-1">Default hotkeys</strong>
                                 <span><kbd>Cmd / Ctrl + P</kbd> – Reload Map when in a Lobby</span>
                                 <span><kbd>Cmd / Ctrl + H</kbd> – Hide currently open Map</span>
+                            </div>
+                        </div>
+
+                        <!-- Stream Deck Tab -->
+                        <div class="tab-pane fade" id="settings-stream-deck" role="tabpanel">
+                            <form>
+                                <p><strong>Choose your Stream Controller Installation:</strong></p>
+
+                                <label>
+                                    <input type="radio" name="streamControllerInstall" value="flatpak">
+                                    Flatpak
+                                </label><br>
+
+                                <label>
+                                    <input type="radio" name="streamControllerInstall" value="system">
+                                    Choose output dir manually
+                                </label><br>
+                            </form>
+                            <button class="btn btn-primary mb-3" id="createConfigs">
+                                Create Configs
+                            </button>
+
+                            <div class="alert alert-warning py-3 px-4 mb-4">
+                                <h5 class="alert-heading mb-2">Font Awesome Required</h5>
+                                <p class="mb-0">
+                                    Make sure that 
+                                    <strong>Font Awesome</strong> is installed in your Stream Controller setup — otherwise, the icons will not appear correctly.
+                                </p>
+                            </div>
+                            
+                            <div class="alert alert-secondary py-3 px-4 mb-4">
+                                <h5 class="alert-heading mb-2">Stream Controller Support</h5>
+                                <p class="mb-1">
+                                    This feature currently works only with 
+                                    <a href="https://github.com/StreamController/StreamController" target="_blank" rel="noopener noreferrer">
+                                    Stream Controller</a>, a Linux application for managing stream decks.
+                                </p>
+                                <p class="mb-0">
+                                    You can also 
+                                    <a href="https://github.com/LucaFontanot/dbd-map-overlay?tab=readme-ov-file#command-line-usage" target="_blank" rel="noopener noreferrer">
+                                    use the command line support
+                                    </a> for integration with other setups.
+                                </p>
                             </div>
                         </div>
                     </div>

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -101,6 +101,15 @@ class Images {
         $("#creatorSelect").on("input", function (ev) {
             thisRef.displayImages($("#searchbar").val())
         })
+        ipcRenderer.on('show-map-command', (event, arg) => {
+            let mapIamgePath = this.findClosestMapMatch(arg)
+            const response = this.sendMap(mapIamgePath, "standard");
+            if (response) {
+                debugLog("mapCommand::setMap::success", "Map set successfully");
+            } else {
+                debugLog("mapCommand::setMap::error", "Failed to set map");
+            }
+        });
     }
 
     searchMaps(name = '', creator = '') {
@@ -192,6 +201,25 @@ class Images {
 
         return result;
     }
+
+    findClosestMapMatch(mapKey) {
+        const normalizedKey = mapKey.replace(/\\/g, '/').trim().toLowerCase();
+
+        for (const key of Object.keys(this.pathLookup)) {
+            const keyWithoutExt = key.replace(/\.[^.]+$/, '').toLowerCase();
+            if (keyWithoutExt === normalizedKey) {
+                return this.pathLookup[key];
+            }
+        }
+
+        const matches = Object.keys(this.pathLookup).filter(key => key.toLowerCase().includes(normalizedKey));
+        if (matches.length > 0) {
+            return this.pathLookup[matches[0]];
+        }
+
+        return null;
+    }
+
 
     async invalidateCache() {
         debugLog("images::invalidateCache::called");

--- a/src/js/streamdeck.js
+++ b/src/js/streamdeck.js
@@ -1,0 +1,444 @@
+const {debugLog} = require("./logger");
+const { ipcRenderer } = require('electron');
+
+class StreamDeck {
+    constructor(images) {
+        debugLog("StreamDeck::constructor::called");
+        this.images = images;
+        this.buttonCount = 6; // Default button count
+        this.commandPrefix = "dbd-map-tool"; // Default command prefix
+        this.mapDictionary = {}; // Map dictionary from buildMapDictionary
+        this.outputDir = "";
+        this.installType = "flatpak";
+        this.selectedCreator = "";
+        this.loadStreamDeckSupport()
+    }
+
+    async loadStreamDeckSupport() {
+        const self = this;
+        
+        $('#createConfigs').on('click', async function () {
+            await self.handleCreateConfigs();
+        });
+
+        // Listen for radio button changes
+        $('input[name="streamControllerInstall"]').on('change', function() {
+            self.installType = $(this).val();
+        });
+    }
+
+    async handleCreateConfigs() {
+        try {
+            this.mapDictionary = this.images.mapDictionary;
+            // Check if we have map data
+            if (!this.mapDictionary || Object.keys(this.mapDictionary).length === 0) {
+                throw new Error("No map data available. Please load maps first.");
+            }
+
+            // Get configuration from user
+            await this.getConfiguration();
+            
+            // Get maps for selected creator
+            const realms = this.organizeMapsByRealm();
+            
+            if (!realms || Object.keys(realms).length === 0) {
+                throw new Error("No maps found for selected creator");
+            }
+
+            // Create configurations
+            await this.createConfigurations(realms);
+            
+            // Show success message
+            this.showSuccessMessage();
+            
+        } catch (error) {
+            debugLog("StreamDeck::handleCreateConfigs::error", error);
+            this.showErrorMessage(error.message);
+        }
+    }
+
+    async getConfiguration() {
+        return new Promise(async (resolve, reject) => {
+            let modalHtml = ""
+            try {
+                // Get available creators from map dictionary
+                const creators = this.getAvailableCreators();
+                
+                if (!creators || creators.length === 0) {
+                    reject(new Error("No creators available"));
+                    return;
+                }
+                
+                // Create modal dialog for configuration
+                modalHtml = `
+                    <div class="modal fade" id="streamDeckConfigModal" tabindex="-1" style="color: black">
+                        <div class="modal-dialog modal-lg">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title">Stream Deck Configuration</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="mb-3">
+                                        <label for="buttonCount" class="form-label">Number of buttons on your Stream Deck:</label>
+                                        <input type="number" class="form-control" id="buttonCount" value="6" min="1" max="32">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="commandPrefix" class="form-label">Command prefix:</label>
+                                        <input type="text" class="form-control" id="commandPrefix" value="dbd-map-tool">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Select Creator:</label>
+                                        <div class="form-check-container" style="max-height: 200px; overflow-y: auto; border: 1px solid #ddd; padding: 10px; border-radius: 5px;">
+                                            ${creators.map(creator => `
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="radio" name="creatorSelect" value="${creator}" id="creator_${creator}">
+                                                    <label class="form-check-label" for="creator_${creator}">
+                                                        ${creator}
+                                                    </label>
+                                                </div>
+                                            `).join('')}
+                                        </div>
+                                    </div>
+                                    ${this.installType === 'system' ? `
+                                    <div class="mb-3">
+                                        <label for="outputDir" class="form-label">Output directory:</label>
+                                        <div class="input-group">
+                                            <input type="text" class="form-control" id="outputDir" readonly>
+                                            <button class="btn btn-outline-secondary" type="button" id="browseDir">Browse</button>
+                                        </div>
+                                    </div>
+                                    ` : ''}
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="button" class="btn btn-primary" id="confirmConfig">Create</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                `;
+            } catch (error) {
+                reject(error);
+                return;
+            }
+
+            // Remove existing modal if any
+            $('#streamDeckConfigModal').remove();
+            
+            // Add modal to page
+            $('body').append(modalHtml);
+            
+            const modal = new bootstrap.Modal(document.getElementById('streamDeckConfigModal'));
+            modal.show();
+
+            // Handle browse button for system install
+            $('#browseDir').on('click', async () => {
+                try {
+                    const result = await ipcRenderer.invoke('dialog:selectDirectory');
+                    if (result && !result.canceled) {
+                        $('#outputDir').val(result.filePaths[0]);
+                    }
+                } catch (error) {
+                    debugLog("Error selecting directory:", error);
+                }
+            });
+
+            // Handle confirm button
+            $('#confirmConfig').on('click', () => {
+                this.buttonCount = parseInt($('#buttonCount').val()) || 6;
+                this.commandPrefix = $('#commandPrefix').val() || 'dbd-map-tool';
+                this.selectedCreator = $('input[name="creatorSelect"]:checked').val();
+                
+                if (!this.selectedCreator) {
+                    alert('Please select a creator');
+                    return;
+                }
+                
+                if (this.installType === 'system') {
+                    this.outputDir = $('#outputDir').val();
+                    if (!this.outputDir) {
+                        alert('Please select an output directory');
+                        return;
+                    }
+                }
+                
+                modal.hide();
+                resolve();
+            });
+
+            // Handle modal close
+            $('#streamDeckConfigModal').on('hidden.bs.modal', () => {
+                $('#streamDeckConfigModal').remove();
+            });
+        });
+    }
+
+    getAvailableCreators() {
+        return Object.keys(this.mapDictionary);
+    }
+
+    organizeMapsByRealm() {
+        const realms = {};
+        
+        if (!this.mapDictionary[this.selectedCreator]) {
+            return realms;
+        }
+        
+        // Iterate through realms for the selected creator
+        for (const [realmName, maps] of Object.entries(this.mapDictionary[this.selectedCreator])) {
+            realms[realmName] = maps.map(mapName => ({
+                key: `${this.selectedCreator}/${realmName}/${mapName}`,
+                name: mapName,
+                creator: this.selectedCreator
+            }));
+        }
+        
+        return realms;
+    }
+
+    async createConfigurations(realms) {
+        const realmNames = Object.keys(realms);
+        
+        // Create main pages (handle realm overflow)
+        await this.createMainPages(realmNames);
+        
+        // Create realm pages
+        for (const [realmName, maps] of Object.entries(realms)) {
+            await this.createRealmPages(realmName, maps);
+        }
+    }
+
+    async createMainPages(realmNames) {
+        const availableButtons = this.buttonCount - 2; // Reserve 2 buttons for navigation
+        const pagesNeeded = Math.ceil(realmNames.length / availableButtons);
+        
+        for (let page = 0; page < pagesNeeded; page++) {
+            const keys = {};
+            const startIndex = page * availableButtons;
+            const endIndex = Math.min(startIndex + availableButtons, realmNames.length);
+            
+            // Add realm buttons
+            for (let i = startIndex; i < endIndex; i++) {
+                const buttonIndex = i - startIndex;
+                const position = this.getButtonPosition(buttonIndex);
+                const realmName = realmNames[i];
+                
+                keys[position] = {
+                    states: {
+                        "0": {
+                            labels: this.createLabels(realmName),
+                            actions: [{
+                                id: "com_core447_DeckPlugin::ChangePage",
+                                settings: {
+                                    selected_page: this.getPagePath(`${realmName}_page1.json`),
+                                    deck_number: null
+                                }
+                            }],
+                            "image-control-action": null,
+                            "label-control-actions": [0, 0, 0],
+                            "background-control-action": 0,
+                            media: { path: null }
+                        }
+                    }
+                };
+            }
+            
+            // Add navigation arrows if multiple pages
+            if (pagesNeeded > 1) {
+                // Previous page button (if not first page)
+                if (page > 0) {
+                    const prevPosition = this.getButtonPosition(this.buttonCount - 2);
+                    keys[prevPosition] = this.createNavigationButton(
+                        "arrow-left.svg",
+                        page === 1 ? "DeadByDaylight.json" : `DeadByDaylight_page${page}.json`
+                    );
+                }
+                
+                // Next page button (if not last page)
+                if (page < pagesNeeded - 1) {
+                    const nextPosition = this.getButtonPosition(this.buttonCount - 1);
+                    keys[nextPosition] = this.createNavigationButton(
+                        "arrow-right.svg",
+                        `DeadByDaylight_page${page + 2}.json`
+                    );
+                }
+            }
+            
+            const pageConfig = { keys };
+            const filename = page === 0 ? "DeadByDaylight.json" : `DeadByDaylight_page${page + 1}.json`;
+            await this.savePageConfig(filename, pageConfig);
+        }
+    }
+
+    async createRealmPages(realmName, maps) {
+        const availableButtons = this.buttonCount - 3; // Reserve buttons for back navigation and page navigation
+        const pagesNeeded = Math.ceil(maps.length / availableButtons);
+        
+        for (let page = 0; page < pagesNeeded; page++) {
+            const keys = {};
+            const startIndex = page * availableButtons;
+            const endIndex = Math.min(startIndex + availableButtons, maps.length);
+            
+            // Add back button to main page
+            keys[this.getButtonPosition(this.buttonCount - 1)] = this.createNavigationButton(
+                "arrow-left.svg",
+                "DeadByDaylight.json"
+            );
+            
+            // Add map buttons
+            for (let i = startIndex; i < endIndex; i++) {
+                const buttonIndex = i - startIndex;
+                const position = this.getButtonPosition(buttonIndex);
+                const map = maps[i];
+                
+                keys[position] = {
+                    states: {
+                        "0": {
+                            labels: this.createLabels(map.name),
+                            actions: [{
+                                id: "com_core447_OSPlugin::RunCommand",
+                                settings: {
+                                    command: `"${this.commandPrefix}" show-map="${map.key}"`
+                                }
+                            }],
+                            "image-control-action": null,
+                            "label-control-actions": [0, 0, 0],
+                            "background-control-action": 0,
+                            media: { path: null }
+                        }
+                    }
+                };
+            }
+            
+            // Add navigation arrows for multiple pages
+            if (pagesNeeded > 1) {
+                // Previous page button
+                if (page > 0) {
+                    const prevPosition = this.getButtonPosition(this.buttonCount - 3);
+                    keys[prevPosition] = this.createNavigationButton(
+                        "arrow-left.svg",
+                        page === 1 ? `${realmName}_page1.json` : `${realmName}_page${page}.json`
+                    );
+                }
+                
+                // Next page button
+                if (page < pagesNeeded - 1) {
+                    const nextPosition = this.getButtonPosition(this.buttonCount - 2);
+                    keys[nextPosition] = this.createNavigationButton(
+                        "arrow-right.svg",
+                        `${realmName}_page${page + 2}.json`
+                    );
+                }
+            }
+            
+            const pageConfig = { keys };
+            await this.savePageConfig(`${realmName}_page${page + 1}.json`, pageConfig);
+        }
+    }
+
+    createNavigationButton(iconName, targetPage) {
+        return {
+            states: {
+                "0": {
+                    media: {
+                        path: this.getIconPath(iconName)
+                    },
+                    actions: [{
+                        id: "com_core447_DeckPlugin::ChangePage",
+                        settings: {
+                            selected_page: this.getPagePath(targetPage),
+                            deck_number: null
+                        }
+                    }],
+                    "image-control-action": 0,
+                    "label-control-actions": [0, 0, 0],
+                    "background-control-action": 0
+                }
+            }
+        };
+    }
+
+    createLabels(text) {
+        let nameWithoutExt = text.replace(/\.[^/.]+$/, "");
+        const words = nameWithoutExt.split(' ');
+        const labels = {};
+        
+        if (words.length === 1) {
+            labels.center = { text: words[0] };
+        } else if (words.length === 2) {
+            labels.top = { text: words[0] };
+            labels.center = { text: words[1] };
+        } else {
+            labels.top = { text: words[0] };
+            labels.center = { text: words.slice(1, -1).join(' ') };
+            labels.bottom = { text: words[words.length - 1] };
+        }
+        
+        return labels;
+    }
+
+    getButtonPosition(index) {
+        // Convert linear index to grid position (assuming 3x2 grid for 6 buttons)
+        const cols = Math.ceil(Math.sqrt(this.buttonCount));
+        const row = Math.floor(index / cols);
+        const col = index % cols;
+        return `${col}x${row}`;
+    }
+
+    getIconPath(iconName) {
+        if (this.installType === 'flatpak') {
+            return `/home/${process.env.USER}/.var/app/com.core447.StreamController/data/icons/com_axolotlmaid_FontAwesomeIcons/icons/white/${iconName}`;
+        } else {
+            return `${this.outputDir}/icons/white/${iconName}`;
+        }
+    }
+
+    getPagePath(filename) {
+        if (this.installType === 'flatpak') {
+            return `/home/${process.env.USER}/.var/app/com.core447.StreamController/data/pages/${filename}`;
+        } else {
+            return `${this.outputDir}/pages/${filename}`;
+        }
+    }
+
+    async savePageConfig(filename, config) {
+        try {
+            const filePath = this.getPagePath(filename);
+            await ipcRenderer.invoke('streamdeck:saveConfig', filePath, config);
+            debugLog(`StreamDeck::savePageConfig::saved ${filename}`);
+        } catch (error) {
+            debugLog(`StreamDeck::savePageConfig::error saving ${filename}:`, error);
+            throw error;
+        }
+    }
+
+    showSuccessMessage() {
+        const alertHtml = `
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                <strong>Success!</strong> Stream Deck configurations have been created successfully.
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        `;
+        
+        $('#settings-stream-deck').prepend(alertHtml);
+        
+        // Auto-dismiss after 5 seconds
+        setTimeout(() => {
+            $('.alert-success').alert('close');
+        }, 5000);
+    }
+
+    showErrorMessage(message) {
+        const alertHtml = `
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <strong>Error!</strong> ${message}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        `;
+        
+        $('#settings-stream-deck').prepend(alertHtml);
+    }
+}
+
+module.exports = StreamDeck;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -9,6 +9,7 @@ const {BASEURL} = require("./js/consts");
 const Images = require("./js/images.js");
 const Hotkeys = require("./js/hotkeys.js")
 const Options = require("./js/options.js");
+const StreamDeck = require("./js/streamdeck.js");
 
 let timeoutHide = null;
 ipcRenderer.on("update-message", async (event, message) => {
@@ -71,6 +72,12 @@ const privacy = new Privacy();
  * @type {Custom}
  */
 const custom = new Custom(images);
+
+/**
+ * Custom instance for handling stream deck config export.
+ * @type {StreamDeck}
+ */
+const streamDeck = new StreamDeck(images);
 
 
 (async function () {


### PR DESCRIPTION
This PR adds Stream Deck support to the application, allowing users to control maps directly from their Stream Deck devices through the [Stream Controller](https://github.com/StreamController/StreamController) software.

Resolves #6 

![IMG_8301](https://github.com/user-attachments/assets/ee28ae8c-8438-4189-be58-bc6accd0a31f)

